### PR TITLE
Fix crash

### DIFF
--- a/spDownload.py
+++ b/spDownload.py
@@ -3,6 +3,9 @@ def download_video(self, request, title, artist, album, bpm, key, energy, path, 
     import spData as data
     import re
 
+    title = title.replace("/", "⧸")
+    artist = artist.replace("/", "⧸")
+
     def progress_hook(d):
         status = d['status']
         if status == 'downloading':
@@ -41,7 +44,7 @@ def download_video(self, request, title, artist, album, bpm, key, energy, path, 
     }
     with ydl.YoutubeDL(ydl_opts) as ydl:
         try:
-            ydl.download([request])
+            ydl.download(["\""+request+"\""])
         except FileNotFoundError:
             self.songProgress_updated.emit(0)
             self.totalProgress_updated.emit(0)

--- a/spPlaylist.py
+++ b/spPlaylist.py
@@ -51,6 +51,7 @@ def call_playlist(creator, playlist_id, keys):
                 print(e)
                 print("\n")
                 return
+            # create dictionary with plalist id 
 
             for track in playlist:
                 counter+=1

--- a/spPlaylist.py
+++ b/spPlaylist.py
@@ -51,7 +51,6 @@ def call_playlist(creator, playlist_id, keys):
                 print(e)
                 print("\n")
                 return
-            # create dictionary with plalist id 
 
             for track in playlist:
                 counter+=1


### PR DESCRIPTION
Songs with a "/" in there name or artist would crash as it messed up the file path in the ytdl module. And there were also problems with songs with a ":" in them
# examples:
https://open.spotify.com/playlist/2uIFxEiTfzWlIiy6wVsoKi
